### PR TITLE
Fix: 댓글 수정 및 삭제, 게시글/좋아요/댓글 생성 관련 권한 설정

### DIFF
--- a/board/src/main/java/com/example/board/article/service/ArticleService.java
+++ b/board/src/main/java/com/example/board/article/service/ArticleService.java
@@ -99,7 +99,7 @@ public class ArticleService {
         String loginUserId = userService.getLoginUserInfo().getUserId();
         String authorUserId = article.getUser().getUserId();
         if (!Objects.equals(loginUserId, authorUserId)) {
-            throw new AccessDeniedException("Login user does not match author");
+            throw new AccessDeniedException("no permission to update article");
         }
         article.update(reqDto.getTitle(), reqDto.getContent());
         articleRepository.save(article);
@@ -112,7 +112,7 @@ public class ArticleService {
         String loginUserId = userService.getLoginUserInfo().getUserId();
         String authorUserId = article.getUser().getUserId();
         if (!Objects.equals(loginUserId, authorUserId)) {
-            throw new AccessDeniedException("Login user does not match author");
+            throw new AccessDeniedException("no permission to delete article");
         }
         articleRepository.deleteById(id);
     }

--- a/board/src/main/java/com/example/board/comment/service/CommentService.java
+++ b/board/src/main/java/com/example/board/comment/service/CommentService.java
@@ -12,6 +12,7 @@ import com.example.board.user.model.entity.User;
 import com.example.board.user.repository.UserRepository;
 import com.example.board.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +48,11 @@ public class CommentService {
     @Transactional
     public UpdateCommentResDto updateComment(Long id, UpateCommentReqDto reqDto) {
         Comment comment = commentRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("No Comment Found"));
+        String authorUserId = comment.getUser().getUserId();
+        String loginUserId = userService.getLoginUserInfo().getUserId();
+        if (!authorUserId.equals(loginUserId)) {
+            throw new AccessDeniedException("no permission to update comment");
+        }
         comment.updateContent(reqDto.getContent());
         commentRepository.save(comment);
         return new UpdateCommentResDto(comment);
@@ -56,6 +62,12 @@ public class CommentService {
     public void deleteComment(Long id) {
         Comment comment = commentRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Comment Not Found"));
         Article article = articleRepository.findById(comment.getArticle().getId()).orElseThrow(() -> new IllegalArgumentException("Article Not Found"));
+        String authorUserId = comment.getUser().getUserId();
+        String loginUserId = userService.getLoginUserInfo().getUserId();
+        if (!authorUserId.equals(loginUserId)) {
+            throw new AccessDeniedException("no permission to delete comment");
+        }
+
         if(comment.getParent() != null) {
             commentRepository.deleteById(id);
         }

--- a/board/src/main/java/com/example/board/config/WebSecurityConfig.java
+++ b/board/src/main/java/com/example/board/config/WebSecurityConfig.java
@@ -26,7 +26,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/", "/login", "/api/user/signup", "/api/article", "/api/article/{id}", "/api/like", "/api/like/{id}", "/api/comment", "/api/comment/{id}").permitAll()
+                        auth.requestMatchers("/", "/login", "/api/user/signup").permitAll()
                                 .requestMatchers(PathRequest.toH2Console()).permitAll()
                                 .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 구현사항
- 댓글 수정/삭제 관련 권한 설정
  - 로그인 사용자와 댓글 작성자가 일치할 경우 권한 부여
- 게시글 작성/좋아요 누르기/댓글 작성 관련 권한 설정
  - Spring Security에 의해 인증된 사용자만 해당 기능 사용 가능   