### PR TITLE
Feat: 로그인 페이지 화면 개발

### DIFF
--- a/board/src/main/java/com/example/board/config/CustomFailureHandler.java
+++ b/board/src/main/java/com/example/board/config/CustomFailureHandler.java
@@ -1,0 +1,42 @@
+package com.example.board.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+
+@Component
+@Slf4j
+public class CustomFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        String message;
+        log.info("customfailurehandler start");
+        if (exception instanceof BadCredentialsException) {
+            message = "아이디 또는 비밀번호가 일치하지 않습니다.";
+        } else if (exception instanceof InternalAuthenticationServiceException) {
+            message = "내부적으로 발생한 시스템 문제로 인해 요청을 처리할 수 없습니다.";
+        } else if (exception instanceof UsernameNotFoundException) {
+            message = "존재하지 않는 계정입니다.";
+        } else if (exception instanceof AuthenticationCredentialsNotFoundException) {
+            message = "인증 요청이 거부되었습니다";
+        } else {
+            message = "알 수 없는 이유로 로그인에 실패하였습니다.";
+        }
+
+        message = URLEncoder.encode(message, "UTF-8");
+        setDefaultFailureUrl("/login?error=true&exception=" + message);
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/board/src/main/java/com/example/board/config/CustomFailureHandler.java
+++ b/board/src/main/java/com/example/board/config/CustomFailureHandler.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @Slf4j
@@ -22,20 +23,17 @@ public class CustomFailureHandler extends SimpleUrlAuthenticationFailureHandler 
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException, ServletException {
         String message;
-        log.info("customfailurehandler start");
-        if (exception instanceof BadCredentialsException) {
+        if (exception instanceof BadCredentialsException || exception instanceof UsernameNotFoundException) {
             message = "아이디 또는 비밀번호가 일치하지 않습니다.";
         } else if (exception instanceof InternalAuthenticationServiceException) {
             message = "내부적으로 발생한 시스템 문제로 인해 요청을 처리할 수 없습니다.";
-        } else if (exception instanceof UsernameNotFoundException) {
-            message = "존재하지 않는 계정입니다.";
         } else if (exception instanceof AuthenticationCredentialsNotFoundException) {
             message = "인증 요청이 거부되었습니다";
         } else {
             message = "알 수 없는 이유로 로그인에 실패하였습니다.";
         }
 
-        message = URLEncoder.encode(message, "UTF-8");
+        message = URLEncoder.encode(message, StandardCharsets.UTF_8);
         setDefaultFailureUrl("/login?error=true&exception=" + message);
         super.onAuthenticationFailure(request, response, exception);
     }

--- a/board/src/main/java/com/example/board/config/WebSecurityConfig.java
+++ b/board/src/main/java/com/example/board/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.board.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +16,10 @@ import static org.springframework.boot.autoconfigure.security.servlet.PathReques
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class WebSecurityConfig {
+
+    private final CustomFailureHandler customFailureHandler;
 
     @Bean
     public WebSecurityCustomizer configure() {
@@ -32,13 +36,11 @@ public class WebSecurityConfig {
                 )
                 .formLogin(auth -> auth
                         .loginPage("/login")
+                        .failureHandler(customFailureHandler)
+                        .usernameParameter("userId")
+                        .passwordParameter("password")
                         .defaultSuccessUrl("/")
-                        .failureUrl("/")
-                        .permitAll()
-                        .failureHandler((request, response, exception) -> {
-                            System.out.println("Login failed: " + exception.getMessage());
-                            response.sendRedirect("/");
-                        })
+//                        .failureUrl("/")
                 )
                 .logout(logout -> logout.logoutSuccessUrl("/").permitAll())
 

--- a/board/src/main/java/com/example/board/user/controller/UserViewController.java
+++ b/board/src/main/java/com/example/board/user/controller/UserViewController.java
@@ -4,19 +4,28 @@ import com.example.board.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class UserViewController {
     private final UserService userService;
 
     @GetMapping("/login")
-    public String login(Model model) {
+    public String login(
+            Model model,
+            @RequestParam(value = "error", required = false) String error,
+            @RequestParam(value = "exception", required = false) String exception
+    ) {
+        model.addAttribute("error", error);
+        model.addAttribute("exception", exception);
         model.addAttribute("authPrincipal", userService.getAuthenticationPrincipal());
         return "user/login";
     }

--- a/board/src/main/java/com/example/board/user/service/UserDetailService.java
+++ b/board/src/main/java/com/example/board/user/service/UserDetailService.java
@@ -1,19 +1,19 @@
-//package com.example.board.user.service;
-//
-//import com.example.board.user.repository.UserRepository;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.core.userdetails.UserDetails;
-//import org.springframework.security.core.userdetails.UserDetailsService;
-//import org.springframework.security.core.userdetails.UsernameNotFoundException;
-//import org.springframework.stereotype.Service;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class UserDetailService implements UserDetailsService {
-//    private final UserRepository userRepository;
-//
-//    @Override
-//    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-//        return userRepository.findByUserId(userId).orElseThrow(() -> new IllegalArgumentException(userId));
-//    }
-//}
+package com.example.board.user.service;
+
+import com.example.board.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        return userRepository.findByUserId(userId).orElseThrow(() -> new UsernameNotFoundException("userId not found"));
+    }
+}

--- a/board/src/main/java/com/example/board/user/service/UserDetailService.java
+++ b/board/src/main/java/com/example/board/user/service/UserDetailService.java
@@ -1,19 +1,19 @@
-package com.example.board.user.service;
-
-import com.example.board.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Service;
-
-@Service
-@RequiredArgsConstructor
-public class UserDetailService implements UserDetailsService {
-    private final UserRepository userRepository;
-
-    @Override
-    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-        return userRepository.findByUserId(userId).orElseThrow(() -> new IllegalArgumentException(userId));
-    }
-}
+//package com.example.board.user.service;
+//
+//import com.example.board.user.repository.UserRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.core.userdetails.UserDetails;
+//import org.springframework.security.core.userdetails.UserDetailsService;
+//import org.springframework.security.core.userdetails.UsernameNotFoundException;
+//import org.springframework.stereotype.Service;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class UserDetailService implements UserDetailsService {
+//    private final UserRepository userRepository;
+//
+//    @Override
+//    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+//        return userRepository.findByUserId(userId).orElseThrow(() -> new IllegalArgumentException(userId));
+//    }
+//}

--- a/board/src/main/java/com/example/board/util/DataInitializer.java
+++ b/board/src/main/java/com/example/board/util/DataInitializer.java
@@ -1,5 +1,7 @@
 package com.example.board.util;
 
+import com.example.board.article.model.entity.Article;
+import com.example.board.article.repository.ArticleRepository;
 import com.example.board.user.model.entity.User;
 import com.example.board.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
     private final UserRepository userRepository;
+    private final ArticleRepository articleRepository;
     private final BCryptPasswordEncoder encoder;
 
     @Override
@@ -39,6 +42,16 @@ public class DataInitializer implements CommandLineRunner {
             testUsers.add(user2);
 
             userRepository.saveAll(testUsers);
+
+            List<Article> articles = new ArrayList<>();
+            for (int i = 1; i <= 5; i++) {
+                articles.add(new Article("제목 " + i, "내용입니다. 내용입니다. 내용입니다. ", user1));
+                articles.add(new Article("제목 " + i, "내용입니다. 내용입니다. 내용입니다. ", user2));
+            }
+
+            articleRepository.saveAll(articles);
         }
+
+
     }
 }

--- a/board/src/main/java/com/example/board/util/DataInitializer.java
+++ b/board/src/main/java/com/example/board/util/DataInitializer.java
@@ -1,0 +1,44 @@
+package com.example.board.util;
+
+import com.example.board.user.model.entity.User;
+import com.example.board.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder encoder;
+
+    @Override
+    public void run(String[] args) {
+        if (userRepository.count() == 0) {
+            List<User> testUsers = new ArrayList<>();
+
+            User user1 = new User(
+                    "test1",
+                    encoder.encode("test1"),
+                    "테스트유저1",
+                    "test1@test1.com"
+            );
+
+            User user2 = new User(
+                    "test2",
+                    encoder.encode("test2"),
+                    "테스트유저2",
+                    "test2@test2.com"
+            );
+
+            testUsers.add(user1);
+            testUsers.add(user2);
+
+            userRepository.saveAll(testUsers);
+        }
+    }
+}

--- a/board/src/main/resources/static/css/user/login.css
+++ b/board/src/main/resources/static/css/user/login.css
@@ -1,0 +1,27 @@
+.section-container {
+    align-items: center;
+}
+
+form {
+    background-color: rgba(239, 239, 239, 0.52);
+    border-radius: 10px;
+    margin-top: 5vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 40vh;
+    width: 20vw;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+}
+
+input {
+    height: 3vh;
+    border: 1px solid black;
+    border-radius: 10px;
+    margin-top: 10px;
+}
+
+span p {
+    color: red;
+}

--- a/board/src/main/resources/templates/index.html
+++ b/board/src/main/resources/templates/index.html
@@ -7,7 +7,6 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="stylesheet" th:href="@{/css/common/common.css}">
     <link rel="stylesheet" th:href="@{/css/index.css}">
-    <script th:src="@{/js/index.js}"></script>
     <title>Document</title>
 </head>
 <body>

--- a/board/src/main/resources/templates/user/login.html
+++ b/board/src/main/resources/templates/user/login.html
@@ -5,40 +5,56 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" th:href="@{/css/common/common.css}">
+    <link rel="stylesheet" th:href="@{/css/user/login.css}">
     <title>Document</title>
 </head>
 <body>
-<section>
     <!-- 공통 header-->
-    <header id="common-header">
-        <a id="header-title" onclick="location.href='/'">서비스 로고</a>
+    <header class="common-header">
+        <div class="common-header-container">
+            <a class="header-title" onclick="location.href='/'" cursor="pointer">서비스 로고</a>
 
-        <div th:if="${authPrincipal != 'anonymousUser'}">
-            <button type="button" onclick="location.href='/mypage'">마이페이지</button>
-            <button type="button" onclick="location.href='/logout'">로그아웃</button>
-        </div>
-        <div th:if="${authPrincipal == 'anonymousUser'}">
-            <button type="button" onclick="location.href='/login'">로그인</button>
-            <button type="button" onclick="location.href='/signup'">회원가입</button>
+            <div th:if="${authPrincipal != 'anonymousUser'}">
+                <button type="button" onclick="location.href='/mypage'">마이페이지</button>
+                <button type="button" onclick="location.href='/logout'">로그아웃</button>
+            </div>
+            <div th:if="${authPrincipal == 'anonymousUser'}">
+                <button type="button" onclick="location.href='/login'">로그인</button>
+                <button type="button" onclick="location.href='/signup'">회원가입</button>
+            </div>
         </div>
     </header>
     <!-- 공통 header-->
 
-    <div>
-        <form action="/login" method="POST">
-            <input type="hidden" th:name="${_csrf?.parameterName}" th:value="${_csrf?.token}"/>
-            <label>
-                <input type="text" name="username" placeholder="아이디" required>
-            </label>
-            <label>
-                <input type="password" name="password" placeholder="비밀번호" required>
-            </label>
-            <input type="submit" value="로그인">
-        </form>
-    </div>
-</section>
+    <section>
+        <div class="section-container">
+            <div class="section-container-title">
+                로그인
+            </div>
+            <form action="/login" method="POST">
+                <input type="hidden" th:name="${_csrf?.parameterName}" th:value="${_csrf?.token}"/>
+                <label>
+                    <input class="input-text" type="text" name="username" placeholder="아이디" required>
+                </label>
+                <label>
+                    <input class="input-text" type="password" name="password" placeholder="비밀번호" required>
+                </label>
+                <input type="submit" value="로그인">
+                <span th:if="${error}">
+                    <p th:text="${exception}"></p>
+                </span>
+            </form>
+        </div>
+    </section>
 
-
-<!--<script src="/js/user/login.js"></script>-->
+    <!-- 공통 footer -->
+    <footer class="common-footer">
+        <div class="common-footer-container">
+            <a class="common-footer-title" onclick="location.href='/'" cursor="pointer">서비스 로고</a>
+            <div class="common-footer-copyright">Copyright 2025. 장한빛. All rights reserved.</div>
+        </div>
+    </footer>
+    <!-- 공통 footer -->
 </body>
 </html>

--- a/board/src/main/resources/templates/user/login.html
+++ b/board/src/main/resources/templates/user/login.html
@@ -35,7 +35,7 @@
             <form action="/login" method="POST">
                 <input type="hidden" th:name="${_csrf?.parameterName}" th:value="${_csrf?.token}"/>
                 <label>
-                    <input class="input-text" type="text" name="username" placeholder="아이디" required>
+                    <input class="input-text" type="text" name="userId" placeholder="아이디" required>
                 </label>
                 <label>
                     <input class="input-text" type="password" name="password" placeholder="비밀번호" required>


### PR DESCRIPTION
## 구현사항
- 로그인 화면 html 개발
- 잘못된 아이디, 비밀번호 입력에 대한 예외처리
- 초기 데이터 삽입 메서드 생성
  - 유저, 게시글 데이터 생성 

## 트러블슈팅
- 문제상황
  - 실제로 존재하는 아이디, 비밀번호를 정확히 입력해도 `InternalAuthenticationServiceException` 예외가 발생해 `CustomExcpetionHandler`에 설정한대로 아이디와 비밀번호가 맞지 않는다는 오류 문구가 출력됨.
- 원인
  - `UserDetailsService`를 구현한 클래스의 `loadUserByUsername`의 파라미터 변수명은 로그인 시 form을 통해 전달되는 데이터의 파라미터 이름과 동일해야 함. 전자를 `userId`로 설정하고, 후자(input 태그의 name 속성의 속성값)를 `username`으로 설정한 것이 화근이었음.
  - 정확한 아이디, 비밀번호를 입력해도 입력된 아이디를 애초에 찾지 못하고, 덩달이 아이디에 따라 유저를 찾지 못하니, 당시 `loadUserByUsername`이 발생시켰던 `IllegalArgumentException`이 발생해 `InternalAuthenticationServiceException`으로 이어졌던 것 
- 해결 
  - input 태그의 name 속성값을 username에서 userId로 수정하니 해결됨
- 여전히 존재하는 아쉬운 점
  -  `loadUserByUsername`이 `UsernameNotFoundException`을 발생시키도록 수정했지만 존재하지 않는 아이디를 입력해도 여전히 BadCredentialsException이 발생함
  - => 아쉬운대로 `BadCredentialsException`과 `UsernameNotFoundException`에 대해 같은 에러 메시지를 반환하도록 `CustomExceptionHandler`를 수정함