### PR TITLE
Feat: 회원가입 화면 개발

### DIFF
--- a/board/build.gradle
+++ b/board/build.gradle
@@ -52,6 +52,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security:3.4.2'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// devtools
+	implementation 'org.springframework.boot:spring-boot-devtools:3.4.2'
+
 }
 
 tasks.named('test') {

--- a/board/src/main/java/com/example/board/config/WebSecurityConfig.java
+++ b/board/src/main/java/com/example/board/config/WebSecurityConfig.java
@@ -30,7 +30,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/", "/login", "/dashboard", "/api/user/signup").permitAll()
+                        auth.requestMatchers("/", "/login", "/signup", "/dashboard", "/api/user/signup").permitAll()
                                 .requestMatchers(PathRequest.toH2Console()).permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/board/src/main/java/com/example/board/exception/CustomValidationException.java
+++ b/board/src/main/java/com/example/board/exception/CustomValidationException.java
@@ -1,0 +1,17 @@
+package com.example.board.exception;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class CustomValidationException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, String> errorMap;
+
+    public CustomValidationException(String message, Map<String, String> errorMap) {
+        super(message);
+        this.errorMap = errorMap;
+    }
+}

--- a/board/src/main/java/com/example/board/exception/CustomValidationException.java
+++ b/board/src/main/java/com/example/board/exception/CustomValidationException.java
@@ -2,13 +2,15 @@ package com.example.board.exception;
 
 import lombok.Getter;
 
+import java.io.Serial;
 import java.util.Map;
 
 @Getter
 public class CustomValidationException extends RuntimeException {
+    @Serial
     private static final long serialVersionUID = 1L;
 
-    private Map<String, String> errorMap;
+    private final Map<String, String> errorMap;
 
     public CustomValidationException(String message, Map<String, String> errorMap) {
         super(message);

--- a/board/src/main/java/com/example/board/exception/GlobalExceptionHandler.java
+++ b/board/src/main/java/com/example/board/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.nio.file.AccessDeniedException;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -19,8 +20,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
+    @ExceptionHandler(CustomValidationException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(CustomValidationException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getErrorMap());
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleGeneralException(Exception e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
+
 }

--- a/board/src/main/java/com/example/board/user/controller/UserController.java
+++ b/board/src/main/java/com/example/board/user/controller/UserController.java
@@ -1,12 +1,19 @@
 package com.example.board.user.controller;
 
+import com.example.board.exception.CustomValidationException;
 import com.example.board.user.model.dto.*;
 import com.example.board.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -16,8 +23,18 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<SignupResDto> signup(@RequestBody SignupReqDto reqDto) {
-        return new ResponseEntity<>(userService.createUser(reqDto), HttpStatus.CREATED);
+    public ResponseEntity<SignupResDto> signup(@Valid @RequestBody SignupReqDto reqDto, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            Map<String, String> errorMap = new HashMap<>();
+
+            for (FieldError error : bindingResult.getFieldErrors()) {
+                errorMap.put(error.getField(), error.getDefaultMessage());
+                log.info("signup error defaultMessage: {}", error.getDefaultMessage());
+            }
+            throw new CustomValidationException("유효성 검사 실패", errorMap);
+        } else {
+            return new ResponseEntity<>(userService.createUser(reqDto), HttpStatus.CREATED);
+        }
     }
 
     @PostMapping("/signout")

--- a/board/src/main/java/com/example/board/user/controller/UserViewController.java
+++ b/board/src/main/java/com/example/board/user/controller/UserViewController.java
@@ -36,6 +36,12 @@ public class UserViewController {
         return "redirect:/";
     }
 
+    @GetMapping("/signup")
+    public String signup(Model model) {
+        model.addAttribute("authPrincipal", userService.getAuthenticationPrincipal());
+        return "user/signup";
+    }
+
     @GetMapping("/mypage")
     public String mypage(Model model) {
         model.addAttribute("authPrincipal", userService.getAuthenticationPrincipal());

--- a/board/src/main/java/com/example/board/user/model/dto/SignupReqDto.java
+++ b/board/src/main/java/com/example/board/user/model/dto/SignupReqDto.java
@@ -1,5 +1,8 @@
 package com.example.board.user.model.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -8,8 +11,22 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class SignupReqDto {
+    @NotBlank
+    @Size(min=4, max=10, message = "4자 이상 10자 이하이어야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{4,10}$", message = "영어 대소문자 또는 숫자만을 사용할 수 있습니다.")
     private String userId;
+
+    @NotBlank
+    @Size(min=4, max=20, message="4자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{4,10}$", message = "영어 대소문자 또는 숫자만을 사용할 수 있습니다.")
     private String password;
+
+    @NotBlank
+    @Size(min=4, max=20, message="4자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{4,20}$", message="영어 대소문자, 한글, 또는 숫자만을 사용할 수 있습니다.")
     private String nickName;
+
+    @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "example@mail.com")
     private String email;
 }

--- a/board/src/main/java/com/example/board/user/model/entity/User.java
+++ b/board/src/main/java/com/example/board/user/model/entity/User.java
@@ -28,23 +28,16 @@ public class User implements UserDetails {
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable=false, length=20, unique=true)
-    @NotBlank
-    @Size(max=20)
+    @Column(nullable=false, unique=true)
     private String userId;
 
-    @Column(nullable=false, length=20)
-    @NotBlank
-    @Size(max=60)
+    @Column(nullable=false)
     private String password;
 
-    @Column(nullable=false, length=20, unique=true)
-    @NotBlank
-    @Size(max=20)
+    @Column(nullable=false, unique=true)
     private String nickName;
 
-    @Column(nullable=false, length=20, unique=true)
-    @NotBlank
+    @Column(nullable=false, unique=true)
     private String email;
 
     @CreatedDate

--- a/board/src/main/java/com/example/board/user/model/entity/User.java
+++ b/board/src/main/java/com/example/board/user/model/entity/User.java
@@ -2,8 +2,7 @@ package com.example.board.user.model.entity;
 
 import com.example.board.article.model.entity.Article;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/board/src/main/resources/static/css/user/signup.css
+++ b/board/src/main/resources/static/css/user/signup.css
@@ -1,0 +1,31 @@
+.section-container {
+    align-items: center;
+}
+
+form {
+    background-color: rgba(239, 239, 239, 0.52);
+    border-radius: 10px;
+    margin-top: 5vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 40vh;
+    width: 20vw;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+}
+
+input {
+    width: 80%;
+    height: 3vh;
+    border: 1px solid black;
+    border-radius: 10px;
+    margin-top: 10px;
+}
+
+span {
+    color: red;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    min-height: 2vh
+}

--- a/board/src/main/resources/static/js/user/signup.js
+++ b/board/src/main/resources/static/js/user/signup.js
@@ -1,0 +1,45 @@
+console.log("signup.js");
+
+function resetErrorMessages() {
+    document.querySelectorAll('.error-message').forEach(message => {
+        if (message.innerText.length !== 0) {
+            message.innerText = ' ';
+        }
+    });
+}
+
+document.getElementById("signup-form").addEventListener('submit', function (e) {
+    e.preventDefault();
+    resetErrorMessages(); // 오류메시지 초기화
+
+    fetch('/api/user/signup', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+                userId: document.getElementById('signup-input-userId').value,
+                password: document.getElementById('signup-input-password').value,
+                nickName: document.getElementById('signup-input-nickName').value,
+                email: document.getElementById('signup-input-email').value
+        })
+    })
+        .then(response => {
+            console.log(response);
+            if (response.ok) {
+                alert('회원가입이 완료되었습니다.');
+                window.location.href = '/login'; // 회원가입 완료 후 로그인 페이지로 이동
+            } else {
+                response.json().then(r => {
+                    Object.keys(r).forEach(key => {
+                        console.log("r[key]: ", r[key]);
+                        document.getElementById(`${key}-error`).innerText = r[key]; // 오류메시지 표기
+                    });
+                });
+            }
+        })
+        .catch(error => {
+            console.log('Error: ', error);
+        });
+
+});

--- a/board/src/main/resources/templates/user/signup.html
+++ b/board/src/main/resources/templates/user/signup.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" th:href="@{/css/common/common.css}">
+    <link rel="stylesheet" th:href="@{/css/user/signup.css}"/>
+    <!--    js 렌더링 o -->
+
+<!--    <script defer src="/js/user/signup.js"></script>-->
+<!--    js 렌더링 x -->
+<!--    <script defer th:href="@{/js/user/signup.js}"></script>-->
+    <script defer th:src="@{/js/user/signup.js}"></script>
+    <title>Document</title>
+</head>
+<body>
+    <!-- 공통 header-->
+    <header class="common-header">
+        <div class="common-header-container">
+            <a class="header-title" onclick="location.href='/'" cursor="pointer">서비스 로고</a>
+
+            <div th:if="${authPrincipal != 'anonymousUser'}">
+                <button type="button" onclick="location.href='/mypage'">마이페이지</button>
+                <button type="button" onclick="location.href='/logout'">로그아웃</button>
+            </div>
+            <div th:if="${authPrincipal == 'anonymousUser'}">
+                <button type="button" onclick="location.href='/login'">로그인</button>
+                <button type="button" onclick="location.href='/signup'">회원가입</button>
+            </div>
+        </div>
+    </header>
+    <!-- 공통 header-->
+
+    <section>
+        <div class="section-container">
+            <div class="section-container-title">
+                회원가입
+            </div>
+            <form class="signup-form" id="signup-form">
+                <input type="hidden" th:name="${_csrf?.parameterName}" th:value="${_csrf?.token}"/>
+
+                <label for="signup-input-userId">아이디</label>
+                <input class="input-text" id="signup-input-userId" type="text" name="userId" required placeholder="아이디는 20자 이내어야 합니다."/>
+                <span class="error-message" id="userId-error"></span>
+
+                <label for="signup-input-password">비밀번호</label>
+                <input class="input-text" id="signup-input-password" type="text" name="password" required
+                       placeholder="비밀번호는 20자 이내어야 합니다."/>
+                <span class="error-message" id="password-error"></span>
+
+                <label for="signup-input-nickName">별명</label>
+                <input class="input-text" id="signup-input-nickName" type="text" name="nickName" required placeholder="별명은 20자 이내어야 합니다."/>
+                <span class="error-message" id="nickName-error"></span>
+
+                <label for="signup-input-email">이메일</label>
+                <input class="input-text" id="signup-input-email" type="email" name="email" required placeholder="이메일 주소 형식을 준수해야 합니다."/>
+                <span class="error-message" id="email-error"></span>
+
+                <input type="submit" value="회원가입"/>
+
+                <span th:if="${error}">
+                    <p th:text="${exception}"></p>
+                </span>
+            </form>
+        </div>
+
+    </section>
+    <!-- 공통 footer -->
+    <footer class="common-footer">
+        <div class="common-footer-container">
+            <a class="common-footer-title" onclick="location.href='/'" cursor="pointer">서비스 로고</a>
+            <div class="common-footer-copyright">Copyright 2025. 장한빛. All rights reserved.</div>
+        </div>
+    </footer>
+    <!-- 공통 footer -->
+
+</body>
+</html>

--- a/board/src/main/resources/templates/user/signup.html
+++ b/board/src/main/resources/templates/user/signup.html
@@ -42,16 +42,15 @@
                 <input type="hidden" th:name="${_csrf?.parameterName}" th:value="${_csrf?.token}"/>
 
                 <label for="signup-input-userId">아이디</label>
-                <input class="input-text" id="signup-input-userId" type="text" name="userId" required placeholder="아이디는 20자 이내어야 합니다."/>
+                <input class="input-text" id="signup-input-userId" type="text" name="userId" required placeholder="아이디는 4자 이상 10자 이하이어야 합니다."/>
                 <span class="error-message" id="userId-error"></span>
 
                 <label for="signup-input-password">비밀번호</label>
-                <input class="input-text" id="signup-input-password" type="text" name="password" required
-                       placeholder="비밀번호는 20자 이내어야 합니다."/>
+                <input class="input-text" id="signup-input-password" type="text" name="password" required placeholder="비밀번호는 4자 이상 20자 이하이야 합니다."/>
                 <span class="error-message" id="password-error"></span>
 
                 <label for="signup-input-nickName">별명</label>
-                <input class="input-text" id="signup-input-nickName" type="text" name="nickName" required placeholder="별명은 20자 이내어야 합니다."/>
+                <input class="input-text" id="signup-input-nickName" type="text" name="nickName" required placeholder="별명은 4자 이상 20자 이하이어야 합니다."/>
                 <span class="error-message" id="nickName-error"></span>
 
                 <label for="signup-input-email">이메일</label>


### PR DESCRIPTION
## 구현사항
- 회원가입 HTML form 
  - => 요청 URL 파라미터 상에 유저 정보를 노출하지 않고, application/json 응답과 `@ResponseBody`를 사용하기 위해 스크립트를 별도로 작성
- 회원가입 요청에 대한 유효성 검증 적용
  - 회원가입 요청 DTO 내부에 설정한 바를 따르지 않는, 유효하지 않은 필드에 대한 오류 문구를 CustomValidationException의 errorMap에 저장
  - HTML 화면 상에 필드별 오류 문구를 출력하도록 함